### PR TITLE
Fix HTML syntax highlighting in markdown renderer

### DIFF
--- a/src/components/MarkdownRenderer/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer/MarkdownRenderer.tsx
@@ -60,7 +60,7 @@ export const MarkdownRenderer: VFC<MarkdownRendererProps> = ({
                                     style={vscDarkPlus}
                                     wrapLongLines
                                     showLineNumbers={!isSafari}
-                                    language={match[1]}
+                                    language={match[1].toLowerCase()}
                                 >
                                     {String(children).replace(/\n$/, '')}
                                 </SyntaxHighlighter>


### PR DESCRIPTION
## PR includes

-   [x] Bug Fix

## Related issues

Resolve #525 

## QA Instructions, Screenshots, Recordings

<img width="811" alt="Screenshot 2024-02-28 at 11 45 16" src="https://github.com/taskany-inc/hire/assets/4553070/935eb22a-853a-44d7-b3ee-19b7e49c306d">
<img width="307" alt="Screenshot 2024-02-28 at 11 45 35" src="https://github.com/taskany-inc/hire/assets/4553070/7b7083d0-8066-49f8-b60b-f27d72786a9e">
